### PR TITLE
fix: corrigir chamada ao método calcTMB no teste de TMB

### DIFF
--- a/__tests__/Unitary/IMC.test.js
+++ b/__tests__/Unitary/IMC.test.js
@@ -19,7 +19,7 @@ describe('calcIMC', () => {
   })
   test('aplicação que retorna o resultado dos calculos do TMB', () => {
     const tmb = calcTMB(70,21,171,'Masculino')
-    expect(tmb.ativo).toBe(2878.59375)
+    expect(tmb[0][4]).toBe(2878.59375)
   })
 
   test('aplicação que retorna o resultado das tabelas do IMC', () => {


### PR DESCRIPTION
Alterado o acesso ao valor `ativo` da função `calcTMB` no teste "aplicação que retorna o resultado dos calculos do TMB" de `tmb.ativo` para `tmb[0][4]`, assim retornando o valor esperado para passar no teste